### PR TITLE
Improved readability in setuptargets + misc. fixes

### DIFF
--- a/datapacks/Chosen/data/praise/functions/assignid.mcfunction
+++ b/datapacks/Chosen/data/praise/functions/assignid.mcfunction
@@ -1,7 +1,6 @@
 # Assign a new unique id to an entity with the tag New
 
-scoreboard players add $Next SacrificeID 0
-scoreboard players operation @e[tag=New,limit=1] SacrificeID = $Next SacrificeID
-tag @e[tag=New,limit=1] remove New
 
-scoreboard players add $Next SacrificeID 1
+scoreboard players add @e[tag=New] SacrificeID 1
+tag @s remove New
+

--- a/datapacks/Chosen/data/praise/functions/menu.mcfunction
+++ b/datapacks/Chosen/data/praise/functions/menu.mcfunction
@@ -1,7 +1,7 @@
 # Display a startup menu
 
 tellraw @s ["\n"]
-tellraw @s [{"text":"Welcome to "},{"text":"Chosen","color":"gold"},{"text":" version "},{"text":"1.2","color":"gold"},{"text":" by "},{"text":"slicedlime","color":"green","clickEvent":{"action":"open_url","value":"https://www.youtube.com/slicedlime"}}]
+tellraw @s [{"text":"Welcome to "},{"text":"Chosen","color":"gold"},{"text":" version "},{"text":"1.3","color":"gold"},{"text":" by "},{"text":"slicedlime","color":"green","clickEvent":{"action":"open_url","value":"https://www.youtube.com/slicedlime"}}]
 tellraw @s [""]
 tellraw @s ["Game options:"]
 tellraw @s [{"text":"- "},{"text":"[","color":"gold","bold": true},{"text":"Game Rules", "color":"green","clickEvent":{"action":"run_command", "value":"/trigger SacrificeMenu set 1"}},{"text":"]","color":"gold", "bold": true}]

--- a/datapacks/Chosen/data/praise/functions/sacrifice.mcfunction
+++ b/datapacks/Chosen/data/praise/functions/sacrifice.mcfunction
@@ -21,7 +21,6 @@ execute if entity @e[tag=Current,tag=CookedPorkchop] at @e[tag=Main] run tag @e[
 execute if entity @e[tag=Current,tag=CookedMutton] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:cooked_mutton"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=CookedChicken] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:cooked_chicken"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=FlowerPot] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:flower_pot"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=GlassBottle] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:glass_bottle"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=SeaGrass] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:seagrass"},OnGround:1b}] add Accepted
 
 execute if entity @e[tag=Current,tag=String] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:string"},OnGround:1b}] add Accepted
@@ -42,7 +41,6 @@ execute if entity @e[tag=Current,tag=Bed] at @e[tag=Main] run tag @e[type=item,d
 execute if entity @e[tag=Current,tag=Bed] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:green_bed"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=Bed] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:red_bed"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=Bed] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:black_bed"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=Fern] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:fern"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=MushroomStew] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:mushroom_stew"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=Bread] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:bread"},OnGround:1b}] add Accepted
 
@@ -60,10 +58,7 @@ execute if entity @e[tag=Current,tag=RabbitStew] at @e[tag=Main] run tag @e[type
 execute if entity @e[tag=Current,tag=FermentedEye] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:fermented_spider_eye"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=MagmaBlock] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:magma_block"},OnGround:1b}] add Accepted
 
-execute if entity @e[tag=Current,tag=Clownfish] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:tropical_fish"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=Clownfish] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:tropical_fish_bucket"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=GlowstoneBlock] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:glowstone"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=PoisonousPotato] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:poisonous_potato"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=SnowBlock] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:snow_block"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=BookAndQuill] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:writable_book"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=FireworkRocket] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:firework_rocket"},OnGround:1b}] add Accepted
@@ -83,12 +78,9 @@ execute if entity @e[tag=Current,tag=Anvil] at @e[tag=Main] run tag @e[type=item
 execute if entity @e[tag=Current,tag=BlazeRod] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:blaze_rod"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=GildedBlackstone] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:gilded_blackstone"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=Shroomlight] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:shroomlight"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=Prismarine] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:prismarine_crystals"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=Diamond] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:diamond"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=Jukebox] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:jukebox"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=FireCharge] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:fire_charge"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=NautilusShell] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:nautilus_shell"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=NetherWartBlock] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:nether_wart_block"},OnGround:1b}] add Accepted
 
 execute if entity @e[tag=Current,tag=MusicDisc] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:music_disc_13"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=MusicDisc] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:music_disc_cat"},OnGround:1b}] add Accepted
@@ -120,12 +112,6 @@ execute if entity @e[tag=Current,tag=HoneyBottle] at @e[tag=Main] run tag @e[typ
 execute if entity @e[tag=Current,tag=MagmaCream] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:magma_cream"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=EndCrystal] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:end_crystal"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=PillagerBanner] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:white_banner",tag:{BlockEntityTag:{Patterns:[{Color:9,Pattern:"mr"},{Color:8,Pattern:"bs"},{Color:7,Pattern:"cs"},{Color:8,Pattern:"bo"},{Color:15,Pattern:"ms"},{Color:8,Pattern:"hh"},{Color:8,Pattern:"mc"},{Color:15,Pattern:"bo"}]}}},OnGround:1b}] add Accepted
-
-execute if entity @e[tag=Current,tag=BannerPattern] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:flower_banner_pattern"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=BannerPattern] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:creeper_banner_pattern"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=BannerPattern] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:skull_banner_pattern"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=BannerPattern] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:mojang_banner_pattern"},OnGround:1b}] add Accepted
-execute if entity @e[tag=Current,tag=BannerPattern] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:globe_banner_pattern"},OnGround:1b}] add Accepted
 
 execute if entity @e[tag=Current,tag=DragonsBreath] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:dragon_breath"},OnGround:1b}] add Accepted
 execute if entity @e[tag=Current,tag=XPBottle] at @e[tag=Main] run tag @e[type=item,distance=..2,nbt={Item:{id:"minecraft:experience_bottle"},OnGround:1b}] add Accepted

--- a/datapacks/Chosen/data/praise/functions/setuptargets.mcfunction
+++ b/datapacks/Chosen/data/praise/functions/setuptargets.mcfunction
@@ -1,244 +1,162 @@
 # Set up target values
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,CoalBlock,A],CustomName:'"Coal Block"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Leather,SamePlural,A],CustomName:'"Leather"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Feather,A],CustomName:'"Feather"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,BrickBlock,A],CustomName:'"Brick Block"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,CookedBeef,A],CustomName:'"Steak"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,CookedPorkchop,A],CustomName:'"Cooked Porkchop"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,CookedMutton,A],CustomName:'"Cooked Mutton"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,CookedChicken,A],CustomName:'"Cooked Chicken"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Apple,An],CustomName:'"Apple"',Duration: 2147483647,Owner:[I;100,75,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,IronIngot,An],CustomName:'"Iron Ingot"',Duration: 2147483647,Owner:[I;100,25,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Leaf,UniquePlural,A],CustomName:'"Leaf"',Duration: 2147483647,Owner:[I;150,75,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=Leaf] ItemId 1
 summon area_effect_cloud ~ 1 ~ {Tags:[LeafPlural,SamePlural],CustomName:'"Leaves"',Duration: 2147483647}
 scoreboard players set @e[tag=LeafPlural] ItemId 1
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,SeaGrass,A,SamePlural],CustomName:'"Sea Grass"',Duration: 2147483647,Owner:[I;150,75,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,FlowerPot,A],CustomName:'"Flower Pot"',Duration: 2147483647,Owner:[I;75,50,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Bone,A],CustomName:'"Bone"',Duration: 2147483647,Owner:[I;200,150,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,RottenFlesh,SamePlural,A],CustomName:'"Rotten Flesh"',Duration: 2147483647,Owner:[I;200,150,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,String,A],CustomName:'"String"',Duration: 2147483647,Owner:[I;200,150,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Gunpowder,A],CustomName:'"Gunpowder"',Duration: 2147483647,Owner:[I;300,200,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,BlackWool,A],CustomName:'"Black Wool Block"',Duration: 2147483647,Owner:[I;200,100,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Bed,A],CustomName:'"Bed"',Duration: 2147483647,Owner:[I;200,100,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Bread,A,SamePlural],CustomName:'"Bread"',Duration: 2147483647,Owner:[I;200,100,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,MushroomStew,A],CustomName:'"Mushroom Stew"',Duration: 2147483647,Owner:[I;400,200,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,FishBucket,A,UniquePlural],CustomName:'"Bucket of Fish"',Duration: 2147483647,Owner:[I;400,200,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=FishBucket] ItemId 3
 summon area_effect_cloud ~ 1 ~ {Tags:[FishBucketPlural,SamePlural],CustomName:'"Buckets of Fish"',Duration: 2147483647}
 scoreboard players set @e[tag=FishBucketPlural] ItemId 3
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,LavaBucket,A],CustomName:'"Lava Bucket"',Duration: 2147483647,Owner:[I;600,200,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,PumpkinPie,A],CustomName:'"Pumpkin Pie"',Duration: 2147483647,Owner:[I;500,500,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,BookAndQuill,A],CustomName:'"Writable Book"',Duration: 2147483647,Owner:[I;500,500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GoldIngot,A],CustomName:'"Gold Ingot"',Duration: 2147483647,Owner:[I;500,150,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,FireworkRocket,A],CustomName:'"Firework Rocket"',Duration: 2147483647,Owner:[I;400,100,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,RedstoneBlock,A],CustomName:'"Redstone Block"',Duration: 2147483647,Owner:[I;400,100,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Bookshelf,UniquePlural,A],CustomName:'"Bookshelf"',Duration: 2147483647,Owner:[I;1000,1000,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=Bookshelf] ItemId 2
-summon area_effect_cloud ~ 1 ~ {Tags:[New,BookshelfPlural,SamePlural],CustomName:'"Bookshelves"',Duration: 2147483647}
-function praise:assignid
+summon area_effect_cloud ~ 1 ~ {Tags:[BookshelfPlural,SamePlural],CustomName:'"Bookshelves"',Duration: 2147483647}
 scoreboard players set @e[tag=BookshelfPlural] ItemId 2
+
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,FermentedEye,A],CustomName:'"Fermented Spider Eye"',Duration: 2147483647,Owner:[I;1000,1000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,MagmaBlock,A],CustomName:'"Magma Block"',Duration: 2147483647,Owner:[I;800,200,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,QuartzBlock,A],CustomName:'"Quartz Block"',Duration: 2147483647,Owner:[I;1500,300,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GlowstoneBlock,A],CustomName:'"Glowstone Block"',Duration: 2147483647,Owner:[I;1500,300,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,LapisBlock,A],CustomName:'"Lapis Lazuli Block"',Duration: 2147483647,Owner:[I;1500,500,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,SpectralArrow,A],CustomName:'"Spectral Arrow"',Duration: 2147483647,Owner:[I;1500,500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Cake,A],CustomName:'"Cake"',Duration: 2147483647,Owner:[I;1500,1000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,TNT,A],CustomName:'"TNT Block"',Duration: 2147483647,Owner:[I;1500,1500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,TargetBlock,A],CustomName:'"Target"',Duration: 2147483647,Owner:[I;800,500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GoldenApple,A],CustomName:'"Golden Apple"',Duration: 2147483647,Owner:[I;2000,1500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GoldenCarrot,A],CustomName:'"Golden Carrot"',Duration: 2147483647,Owner:[I;2000,500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Emerald,An],CustomName:'"Emerald"',Duration: 2147483647,Owner:[I;2000,1000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Cobweb,A],CustomName:'"Cobweb"',Duration: 2147483647,Owner:[I;3000,500,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GlisteringMelon,A],CustomName:'"Glistering Melon Slice"',Duration: 2147483647,Owner:[I;3000,500,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Obsidian,SamePlural,An],CustomName:'"Obsidian"',Duration: 2147483647,Owner:[I;3000,500,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Shroomlight,A],CustomName:'"Shroomlight"',Duration: 2147483647,Owner:[I;3000,500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GrassBlock,A],CustomName:'"Grass Block"',Duration: 2147483647,Owner:[I;3000,3000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Slimeball,A],CustomName:'"Slimeball"',Duration: 2147483647,Owner:[I;3000,2000,0,0]}
-function praise:assignid
 
-summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,FireCharge,A,UniquePlural],CustomName:'"Fire Charge"',Duration: 2147483647,Owner:[I;5000,3000,0,0]}
-function praise:assignid
-scoreboard players set @e[tag=FireCharge] ItemId 8
-summon area_effect_cloud ~ 1 ~ {Tags:[FireChargePlural,SamePlural],CustomName:'"Fire Charges"',Duration: 2147483647}
-scoreboard players set @e[tag=FireChargePlural] ItemId 8
+summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,FireCharge,A],CustomName:'"Fire Charge"',Duration: 2147483647,Owner:[I;5000,3000,0,0]}
+
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,CryingObsidian,SamePlural,A],CustomName:'"Crying Obsidian"',Duration: 2147483647,Owner:[I;5000,3000,0,0]}
-function praise:assignid
 
-summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,T40,Anvil,An],CustomName:'"Anvil"',Duration: 2147483647,Owner:[I;3000,5000,0,0]}
-function praise:assignid
+summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Anvil,An],CustomName:'"Anvil"',Duration: 2147483647,Owner:[I;3000,5000,0,0]}
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Diamond,A],CustomName:'"Diamond"',Duration: 2147483647,Owner:[I;4000,4000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Jukebox,A,UniquePlural],CustomName:'"Jukebox"',Duration: 2147483647,Owner:[I;4000,4000,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=Jukebox] ItemId 7
 summon area_effect_cloud ~ 1 ~ {Tags:[JukeboxPlural,SamePlural],CustomName:'"Jukeboxes"',Duration: 2147483647}
 scoreboard players set @e[tag=JukeboxPlural] ItemId 7
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,MusicDisc,A],CustomName:'"Music Disc"',Duration: 2147483647,Owner:[I;4000,4000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,RabbitStew,A],CustomName:'"Rabbit Stew"',Duration: 2147483647,Owner:[I;4000,1000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,BlazeRod,A],CustomName:'"Blaze Rod"',Duration: 2147483647,Owner:[I;6000,2000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GildedBlackstone,A,SamePlural],CustomName:'"Gilded Blackstone"',Duration: 2147483647,Owner:[I;6000,2000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Saddle,A],CustomName:'"Saddle"',Duration: 2147483647,Owner:[I;6000,8000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,HoneyBottle,A],CustomName:'"Honey Bottle"',Duration: 2147483647,Owner:[I;6000,8000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Cookie,A],CustomName:'"Cookie"',Duration: 2147483647,Owner:[I;10000,1500,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Bamboo,A,SamePlural],CustomName:'"Bamboo"',Duration: 2147483647,Owner:[I;10000,1500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,HeartOfTheSea,A],CustomName:'"Heart of the Sea"',Duration: 2147483647,Owner:[I;7500,7500,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=HeartOfTheSea] ItemId 4
 summon area_effect_cloud ~ 1 ~ {Tags:[HeartOfTheSeaPlural,SamePlural],CustomName:'"Hearts of the Sea"',Duration: 2147483647}
 scoreboard players set @e[tag=HeartOfTheSeaPlural] ItemId 4
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Nametag,A],CustomName:'"Nametag"',Duration: 2147483647,Owner:[I;6000,3000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,AwkwardPotion,An],CustomName:'"Awkward Potion"',Duration: 2147483647,Owner:[I;10000,2000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Bell,A],CustomName:'"Bell"',Duration: 2147483647,Owner:[I;10000,15000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,EnchantedBook,An],CustomName:'"Enchanted Book"',Duration: 2147483647,Owner:[I;15000,7500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,MagmaCream,A],CustomName:'"Magma Cream"',Duration: 2147483647,Owner:[I;15000,7500,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,EnchantingTable,An],CustomName:'"Enchanting Table"',Duration: 2147483647,Owner:[I;20000,20000,0,0]}
-function praise:assignid
-summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GhastTear,A],CustomName:'"Ghast Tear"',Duration: 2147483647,Duration: 2147483647,Owner:[I;20000,20000,0,0]}
-function praise:assignid
+summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,GhastTear,A],CustomName:'"Ghast Tear"',Duration: 2147483647,Owner:[I;20000,20000,0,0]}
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,EndCrystal,An],CustomName:'"End Crystal"',Duration: 2147483647,Owner:[I;30000,25000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,XPBottle,UniquePlural,A],CustomName:'"Bottle of Enchanting"',Duration: 2147483647,Owner:[I;30000,25000,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=XPBottle] ItemId 9
 summon area_effect_cloud ~ 1 ~ {Tags:[XPBottlePlural,SamePlural],CustomName:'"Bottles of Enchanting"',Duration: 2147483647}
 scoreboard players set @e[tag=XPBottlePlural] ItemId 9
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,PillagerBanner,A],CustomName:'"Pillager Banner"',Duration: 2147483647,Owner:[I;40000,20000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,DragonsBreath,SamePlural,A],CustomName:'"Dragon’s Breath"',Duration: 2147483647,Owner:[I;40000,5000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,ChorusFruit,A],CustomName:'"Chorus Fruit"',Duration: 2147483647,Owner:[I;60000,10000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,EndRod,An],CustomName:'"End Rod"',Duration: 2147483647,Owner:[I;80000,15000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,ShulkerShell,A],CustomName:'"Shulker Shell"',Duration: 2147483647,Owner:[I;100000,30000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,WitherSkull,A],CustomName:'"Wither Skull"',Duration: 2147483647,Owner:[I;200000,200000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,DragonHead,A],CustomName:'"Dragon Head"',Duration: 2147483647,Owner:[I;200000,200000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Elytra,SamePlural,An],CustomName:'"Elytra"',Duration: 2147483647,Owner:[I;200000,200000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,NetheriteIngot,A],CustomName:'"Netherite Ingot"',Duration: 2147483647,Owner:[I;200000,200000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,Sponge,A],CustomName:'"Sponge"',Duration: 2147483647,Owner:[I;200000,100000,0,0]}
-function praise:assignid
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,TotemOfUndying,UniquePlural,A],CustomName:'"Totem of Undying"',Duration: 2147483647,Owner:[I;200000,100000,0,0]}
-function praise:assignid
 scoreboard players set @e[tag=TotemOfUndying] ItemId 5
 summon area_effect_cloud ~ 1 ~ {Tags:[TotemPlural,SamePlural],CustomName:'"Totems of Undying"',Duration: 2147483647}
 scoreboard players set @e[tag=TotemPlural] ItemId 5
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,NetherStar,A],CustomName:'"Nether Star"',Duration: 2147483647,Owner:[I;600000,800000,0,0]}
-function praise:assignid
 
 summon area_effect_cloud ~ 1 ~ {Tags:[New,Target,WitherRose,A],CustomName:'"Wither Rose"',Duration: 2147483647,Owner:[I;600000,200000,0,0]}
-function praise:assignid
+
+execute as @e[tag=New] run function praise:assignid
+
 
 scoreboard players set @e[tag=Target] Cooldown 0
 


### PR DESCRIPTION
**Main improvement:**
Condensed all calls to `praise:assignid` into a single call at the end of the file.

**Smaller tweaks:**
- Bumped version number in case this changed the RNG.
- Deleted removed items from `praise:sacrifice`.
- Fixed #10.
- Removed: old `T40` tag from _anvil_; unnecessary custom plural for _fire charge_; extra `Duration` nbt in _ghast tier_.